### PR TITLE
Add fast abs w/tests

### DIFF
--- a/gbdk-lib/libc/Makefile
+++ b/gbdk-lib/libc/Makefile
@@ -12,7 +12,7 @@ endif
 
 TOPDIR = ..
 
-CSRC =	abs.c atoi.c atol.c isalpha.c isdigit.c \
+CSRC =	atoi.c atol.c isalpha.c isdigit.c \
 	islower.c isspace.c isupper.c itoa.c labs.c \
 	printf.c puts.c reverse.c scanf.c strcat.c string.c \
 	strlen.c strncat.c strncmp.c strncpy.c time.c \

--- a/gbdk-lib/libc/asm/gbz80/Makefile
+++ b/gbdk-lib/libc/asm/gbz80/Makefile
@@ -3,7 +3,7 @@
 TOPDIR = ../../..
 
 THIS = gbz80
-ASSRC = mul.s div.s shift.s stubs.s crt0_rle.s
+ASSRC = abs.s mul.s div.s shift.s stubs.s crt0_rle.s
 
 include $(TOPDIR)/Makefile.common
 

--- a/gbdk-lib/libc/asm/gbz80/abs.s
+++ b/gbdk-lib/libc/asm/gbz80/abs.s
@@ -1,0 +1,19 @@
+; int abs(int)
+_abs::
+	; first word is return address
+	; second is argument
+	pop hl
+	pop de ; make copy of de
+	push de ; but leave it on the stack for the caller to clean up
+	ld a, d
+	add a, a
+	jr nc, .done
+	rra
+	cpl
+	ld d, a
+	ld a, e
+	cpl
+	ld e, a
+	inc de
+.done:
+	jp (hl)

--- a/test/absbench.c
+++ b/test/absbench.c
@@ -1,0 +1,44 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <gb/gb.h>
+#include <gb/bgb_emu.h>
+
+#define INT_MAX 0x7fff
+#define INT_MIN (-(INT_MAX) - 1)
+
+volatile int magic;
+
+int safe_abs(int i)
+{
+	if (i < 0)
+		return -i;
+	else
+		return i;
+}
+
+int main(void)
+{
+	int i;
+
+	puts("Starting benchmark...");
+
+	BGB_PROFILE_BEGIN(libr_abs);
+	for (i = -0x7fff - 1; ; i++) {
+		magic = abs(i);
+		if (i == 0x7fff)
+			break;
+	}
+	BGB_PROFILE_END(libr_abs);
+
+	BGB_PROFILE_BEGIN(safe_abs);
+	for (i = -0x7fff - 1; ; i++) {
+		magic = safe_abs(i);
+		if (i == 0x7fff)
+			break;
+	}
+	BGB_PROFILE_END(safe_abs);
+
+	puts("done");
+
+	return 0;
+}

--- a/test/abscheck.c
+++ b/test/abscheck.c
@@ -1,0 +1,30 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <gb/gb.h>
+
+#define INT_MAX 0x7fff
+#define INT_MIN (-(INT_MAX) - 1)
+
+int safe_abs(int i)
+{
+	if (i < 0)
+		return -i;
+	else
+		return i;
+}
+
+int main(void)
+{
+	int i;
+
+	for (i = -0x7fff - 1; ; i++) {
+		if (abs(i) != safe_abs(i))
+			printf("error %d\n", i);
+		if (i == 0x7fff)
+			break;
+	}
+
+	puts("done");
+
+	return 0;
+}


### PR DESCRIPTION
The optimized version takes around 65% of the cycles that the
C version does. Included are a consistency test (which tests
every return value from this abs with the return value from a
known good one), and a benchmark (which uses the BGB macros for
accurate clock cycle counting).

As this passes both the tests I think it's safe to be used by
default.

Credit to @aaaaaa123456789 for golfing the optimized version
down to 15 bytes from my initial attempt which was 20.