### PR TITLE
Replace ld (hl) dec hl with ld (hl-)

### DIFF
--- a/gbdk-lib/libc/asm/gbz80/asm_string.s
+++ b/gbdk-lib/libc/asm/gbz80/asm_string.s
@@ -7,10 +7,10 @@
 ; char *strcpy(char *dest, const char *source)
 _strcpy::
 	lda	hl,2(sp)
-	ld	e,(hl)
-	inc	hl
-	ld	d,(hl)
-	inc	hl
+	ld	a,(hl+)
+	ld	e, a
+	ld	a,(hl+)
+	ld	d, a
 	ld	a,(hl+)
 	ld	h,(hl)
 	ld	l,a
@@ -30,12 +30,12 @@ _strcpy::
 _memcpy::
 	push	bc
 	lda	hl,6(sp)
-	ld	e,(hl)
-	inc	hl
-	ld	d,(hl)
-	inc	hl
-	ld	c,(hl)
-	inc	hl
+	ld	a,(hl+)
+	ld	e, a
+	ld	a,(hl+)
+	ld	d, a
+	ld	a,(hl+)
+	ld	c, a
 	ld	b,(hl)
 	lda	hl,4(sp)
 	ld	a,(hl+)
@@ -64,10 +64,10 @@ _memcpy::
 ; int strcmp(const char *s1, const char *s2) 
 _strcmp::
 	lda	hl,2(sp)
-	ld	e,(hl)
-	inc	hl
-	ld	d,(hl)
-	inc	hl
+	ld	a,(hl+)
+	ld	e, a
+	ld	a,(hl+)
+	ld	d, a
 	ld	a,(hl+)
 	ld	h,(hl)
 	ld	l,a

--- a/gbdk-lib/libc/asm/gbz80/crt0_rle.s
+++ b/gbdk-lib/libc/asm/gbz80/crt0_rle.s
@@ -10,14 +10,13 @@ __initrleblock::
         pop     hl
 1$:
         ;; Fetch the run
-        ld      e,(hl)
-        inc     hl
+        ld      a,(hl+)
+        ld      e, a
         ;; Negative means a run
         bit     7,e
         jp      z,2$
         ;; Code for expanding a run
-        ld      a,(hl)
-        inc     hl
+        ld      a,(hl+)
 3$:
         ld      (bc),a
         inc     bc
@@ -31,8 +30,7 @@ __initrleblock::
         jp      z,4$
         ;; Code for expanding a block
 5$:     
-        ld      a,(hl)        
-        inc     hl
+        ld      a,(hl+)
         ld      (bc),a
         inc     bc
         dec     e

--- a/gbdk-lib/libc/asm/gbz80/div.s
+++ b/gbdk-lib/libc/asm/gbz80/div.s
@@ -74,8 +74,8 @@ __divuschar:
         ld      d, h
         add     hl,sp
 
-        ld      e,(hl)
-        dec     hl
+        ld      a,(hl-)
+        ld      e, a
         ld      c,(hl)
 
         ld      a,c             ; Sign extend
@@ -95,8 +95,8 @@ __moduschar:
         ld      d, h
         add     hl,sp
 
-        ld      e,(hl)
-        dec     hl
+        ld      a,(hl-)
+        ld      e, a
         ld      c,(hl)
 
         ld      a,c             ; Sign extend
@@ -145,12 +145,11 @@ __divsint:
         ld      hl,#2+3
         add     hl,sp
 
-        ld      d,(hl)
-        dec     hl
-        ld      e,(hl)
-        dec     hl
-        ld      a,(hl)
-        dec     hl
+        ld      a,(hl-)
+        ld      d, a
+        ld      a,(hl-)
+        ld      e, a
+        ld      a,(hl-)
         ld      l,(hl)
         ld      h,a
 
@@ -168,12 +167,11 @@ __modsint:
         ld      hl,#2+3
         add     hl,sp
 
-        ld      d,(hl)
-        dec     hl
-        ld      e,(hl)
-        dec     hl
-        ld      a,(hl)
-        dec     hl
+        ld      a,(hl-)
+        ld      d, a
+        ld      a,(hl-)
+        ld      e, a
+        ld      a,(hl-)
         ld      l,(hl)
         ld      h,a
 
@@ -222,12 +220,11 @@ __divuint:
         ld      hl,#2+3
         add     hl,sp
 
-        ld      d,(hl)
-        dec     hl
-        ld      e,(hl)
-        dec     hl
-        ld      a,(hl)
-        dec     hl
+        ld      a,(hl-)
+        ld      d, a
+        ld      a,(hl-)
+        ld      e, a
+        ld      a,(hl-)
         ld      l,(hl)
         ld      h,a
 
@@ -244,12 +241,11 @@ __moduint:
         ld      hl,#2+3
         add     hl,sp
 
-        ld      d,(hl)
-        dec     hl
-        ld      e,(hl)
-        dec     hl
-        ld      a,(hl)
-        dec     hl
+        ld      a,(hl-)
+        ld      d, a
+        ld      a,(hl-)
+        ld      e, a
+        ld      a,(hl-)
         ld      l,(hl)
         ld      h,a
 

--- a/gbdk-lib/libc/asm/gbz80/mul.s
+++ b/gbdk-lib/libc/asm/gbz80/mul.s
@@ -62,8 +62,8 @@ __mulschar:
         ld      hl,#2
         add     hl,sp
 
-        ld      e,(hl)
-        inc     hl
+        ld      a,(hl+)
+        ld      a, e
         ld      l,(hl)
 
         ;; Need to sign extend before going in.
@@ -85,9 +85,9 @@ __muluchar:
         ld      hl,#2
         add     hl,sp
 
-        ld      e,(hl)
+        ld      a,(hl+)
 
-        inc     hl
+        ld      e, a
         ld      c,(hl)
 
         ;; Clear the top
@@ -101,12 +101,11 @@ __mulint:
         ld      hl,#2
         add     hl,sp
 
-        ld      e,(hl)
-        inc     hl
-        ld      d,(hl)
-        inc     hl
-        ld      a,(hl)
-        inc     hl
+        ld      a,(hl+)
+        ld      e, a
+        ld      a,(hl+)
+        ld      d, a
+        ld      a,(hl+)
         ld      h,(hl)
         ld      l,a
 

--- a/gbdk-lib/libc/asm/gbz80/shift.s
+++ b/gbdk-lib/libc/asm/gbz80/shift.s
@@ -3,14 +3,14 @@ __rrulong_rrx_s::
         ld      hl,#2
         add     hl,sp
 
-        ld      e,(hl)
-        inc     hl
-        ld      d,(hl)
-        inc     hl
-        ld      c,(hl)
-        inc     hl
-        ld      b,(hl)
-        inc     hl
+        ld      a,(hl+)
+        ld      e, a
+        ld      a,(hl+)
+        ld      d, a
+        ld      a,(hl+)
+        ld      c, a
+        ld      a,(hl+)
+        ld      b, a
         ld      a,(hl)
 
         ld      l,c
@@ -31,14 +31,14 @@ __rrslong_rrx_s::
         ld      hl,#2
         add     hl,sp
                 
-        ld      e,(hl)
-        inc     hl
-        ld      d,(hl)
-        inc     hl
-        ld      c,(hl)
-        inc     hl
-        ld      b,(hl)
-        inc     hl
+        ld      a,(hl+)
+        ld      e, a
+        ld      a,(hl+)
+        ld      d, a
+        ld      a,(hl+)
+        ld      c, a
+        ld      a,(hl+)
+        ld      b, a
         ld      a,(hl)
 
         ld      l,c
@@ -60,14 +60,14 @@ __rlulong_rrx_s::
         ld      hl,#2
         add     hl,sp
         
-        ld      e,(hl)
-        inc     hl
-        ld      d,(hl)
-        inc     hl
-        ld      c,(hl)
-        inc     hl
-        ld      b,(hl)
-        inc     hl
+        ld      a,(hl+)
+        ld      e, a
+        ld      a,(hl+)
+        ld      d, a
+        ld      a,(hl+)
+        ld      c, a
+        ld      a,(hl+)
+        ld      b, a
         ld      a,(hl)
 
         ld      l,c

--- a/gbdk-lib/libc/gb/arand.s
+++ b/gbdk-lib/libc/gb/arand.s
@@ -102,10 +102,10 @@ _initarand::			; Banked
 	LD	H,B
 	LD	L,C
 
-	LD	(HL),D
-	INC	HL
-	LD	(HL),E
-	INC	HL
+	LD	A, D
+	LD	(HL+),A
+	LD	A, E
+	LD	(HL+),A
 	
 	LD	A,(.raxj)
 	CP	#0

--- a/gbdk-lib/libc/gb/cpy_data.s
+++ b/gbdk-lib/libc/gb/cpy_data.s
@@ -23,14 +23,14 @@ _get_data::
 	PUSH	BC
 
 	LDA	HL,9(SP)	; Skip return address and registers
-	LD	D,(HL)		; DE = len
-	DEC	HL
-	LD	E,(HL)
-	DEC	HL
-	LD	B,(HL)		; BC = src
-	DEC	HL
-	LD	C,(HL)
-	DEC	HL
+	LD	A,(HL-)		; DE = len
+	LD	D, A
+	LD	A,(HL-)
+	LD	E, A
+	LD	A,(HL-)		; BC = src
+	LD	B, A
+	LD	A,(HL-)
+	LD	C, A
 	LD	A,(HL-)		; HL = dst
 	LD	L,(HL)
 	LD	H,A

--- a/gbdk-lib/libc/gb/drawing.s
+++ b/gbdk-lib/libc/gb/drawing.s
@@ -197,10 +197,9 @@
 	LD      B,#0x00
 	ADD     HL,BC
 	ADD     HL,BC
-	LD      B,(HL)
-	INC     HL
+	LD      A,(HL+)
 	LD      H,(HL)
-	LD      L,B
+	LD      L,A
 	ADD     HL,DE
 
 	LD      B,H             ; BC = src
@@ -1481,8 +1480,8 @@ end$:	LD	E,B
 	LD	E,A
 	ADD	HL,DE
 	ADD	HL,DE
-	LD	B,(HL)
-	INC	HL
+	LD	A,(HL+)
+	LD	B, A
 	LD	H,(HL)
 	LD	L,B
 

--- a/gbdk-lib/libc/gb/get_bk_t.s
+++ b/gbdk-lib/libc/gb/get_bk_t.s
@@ -8,14 +8,14 @@ _get_bkg_tiles::
 	PUSH	BC
 
 	LDA	HL,4(SP)	; Skip return address and registers
-	LD	D,(HL)		; D = x
-	INC	HL
+	LD	A,(HL+)		; D = x
+	LD	D, A
 	LD	E,(HL)		; E = y
 	LDA	HL,9(SP)
-	LD	B,(HL)		; BC = tiles
-	DEC	HL
-	LD	C,(HL)
-	DEC	HL
+	LD	A,(HL-)		; BC = tiles
+	LD	B, A
+	LD	A,(HL-)
+	LD	C, A
 	LD	A,(HL-)		; A = h
 	LD	H,(HL)		; H = w
 	LD	L,A		; L = h

--- a/gbdk-lib/libc/gb/get_data.s
+++ b/gbdk-lib/libc/gb/get_data.s
@@ -14,12 +14,12 @@ _get_win_data::
 	PUSH	BC
 
 	LDA	HL,7(SP)	; Skip return address and registers
-	LD	B,(HL)		; BC = data
-	DEC	HL
-	LD	C,(HL)
-	DEC	HL
-	LD	E,(HL)		; E = nb_tiles
-	DEC	HL
+	LD	A,(HL-)		; BC = data
+	LD	B, A
+	LD	A,(HL-)
+	LD	C, A
+	LD	A,(HL-)		; E = nb_tiles
+	LD	E, A
 	LD	L,(HL)		; L = first_tile
 	PUSH	HL
 
@@ -79,12 +79,12 @@ _get_sprite_data::
 	PUSH	BC
 
 	LDA	HL,7(SP)	; Skip return address and registers
-	LD	B,(HL)		; BC = data
-	DEC	HL
-	LD	C,(HL)
-	DEC	HL
-	LD	E,(HL)		; E = nb_tiles
-	DEC	HL
+	LD	A,(HL-)		; BC = data
+	LD	B, A
+	LD	A,(HL-)
+	LD	C, A
+	LD	A,(HL-)		; E = nb_tiles
+	LD	E, A
 	LD	L,(HL)		; L = first_tile
 	PUSH	HL
 

--- a/gbdk-lib/libc/gb/get_wi_t.s
+++ b/gbdk-lib/libc/gb/get_wi_t.s
@@ -8,14 +8,14 @@ _get_win_tiles::
 	PUSH	BC
 
 	LDA	HL,4(SP)	; Skip return address and registers
-	LD	D,(HL)		; D = x
-	INC	HL
+	LD	A,(HL+)		; D = x
+	LD	D, A
 	LD	E,(HL)		; E = y
 	LDA	HL,9(SP)
-	LD	B,(HL)		; BC = tiles
-	DEC	HL
-	LD	C,(HL)
-	DEC	HL
+	LD	A,(HL-)		; BC = tiles
+	LD	B, A
+	LD	A,(HL-)
+	LD	C, A
 	LD	A,(HL-)		; A = h
 	LD	H,(HL)		; H = w
 	LD	L,A		; L = h

--- a/gbdk-lib/libc/gb/get_xy_t.s
+++ b/gbdk-lib/libc/gb/get_xy_t.s
@@ -80,19 +80,19 @@ _get_tiles::
 	PUSH	BC
 
 	LDA	HL,11(SP)	; Skip return address and registers
-	LD	D,(HL)		; DE = src
-	DEC	HL
-	LD	E,(HL)
-	DEC	HL
-	LD	B,(HL)		; BC = dst
-	DEC	HL
+	LD	A,(HL-)		; DE = src
+	LD	D, A
+	LD	A,(HL-)
+	LD	E, A
+	LD	A,(HL-)		; BC = dst
+	LD	B, A
 	LD	C,(HL)
 	LDA	HL,4(SP)	; Skip return address and registers
 	PUSH	DE		; Store address on stack for set_xy_tt
-	LD	D,(HL)		; D = x
-	INC	HL
-	LD	E,(HL)		; E = y
-	INC	HL
+	LD	A,(HL+)		; D = x
+	LD	D, A
+	LD	A,(HL+)		; E = y
+	LD	E, A
 	LD	A,(HL+)		; A = w
 	LD	L,(HL)		; L = h
 	LD	H,A		; H = w

--- a/gbdk-lib/libc/gb/hiramcpy.s
+++ b/gbdk-lib/libc/gb/hiramcpy.s
@@ -26,8 +26,8 @@ _hiramcpy::
 	LDA	HL,4(SP)	; Skip return address and registers
 	LD	C,(HL)		; C = dst
 	LDA	HL,7(SP)
-	LD	B,(HL)		; B = n
-	DEC	HL
+	LD	A,(HL-)		; B = n
+	LD	B, A
 	LD	A,(HL-)		; HL = src
 	LD	L,(HL)
 	LD	H,A

--- a/gbdk-lib/libc/gb/init_tt.s
+++ b/gbdk-lib/libc/gb/init_tt.s
@@ -10,8 +10,8 @@
 	AND	#0x02
 	JR	NZ,1$
 
-	LD	(HL),B
-	INC	HL
+	LD	A, B
+	LD	(HL+),A
 	DEC	DE
 	LD	A,D
 	OR	E

--- a/gbdk-lib/libc/gb/input.s
+++ b/gbdk-lib/libc/gb/input.s
@@ -419,8 +419,8 @@
 	LD	(HL),#>.MINACCEL
 	JR	4$		; Update position
 2$:
-	LD	C,(HL)
-	INC	HL
+	LD	A,(HL+)
+	LD	C, A
 	LD	B,(HL)
 	DEC	BC
 	LD	A,B

--- a/gbdk-lib/libc/gb/mv_spr.s
+++ b/gbdk-lib/libc/gb/mv_spr.s
@@ -22,10 +22,10 @@ _move_sprite::
 	PUSH	BC
 
 	LDA	HL,4(SP)	; Skip return address and registers
-	LD	C,(HL)		; C = nb
-	INC	HL
-	LD	D,(HL)		; D = x
-	INC	HL
+	LD	A,(HL+)		; C = nb
+	LD	C, A
+	LD	A,(HL+)		; D = x
+	LD	D, A
 	LD	E,(HL)		; E = y
 
 	CALL	.mv_sprite

--- a/gbdk-lib/libc/gb/scroll_s.s
+++ b/gbdk-lib/libc/gb/scroll_s.s
@@ -24,10 +24,10 @@ _scroll_sprite::
 	PUSH	BC
 
 	LDA	HL,4(SP)	; Skip return address and registers
-	LD	C,(HL)		; C = nb
-	INC	HL
-	LD	D,(HL)		; D = x
-	INC	HL
+	LD	A,(HL+)		; C = nb
+	LD	C, A
+	LD	A,(HL+)		; D = x
+	LD	D, A
 	LD	E,(HL)		; E = y
 
 	CALL	.scroll_sprite

--- a/gbdk-lib/libc/gb/set_bk_t.s
+++ b/gbdk-lib/libc/gb/set_bk_t.s
@@ -8,14 +8,14 @@ _set_bkg_tiles::
 	PUSH	BC
 
 	LDA	HL,4(SP)	; Skip return address and registers
-	LD	D,(HL)		; D = x
-	INC	HL
+	LD	A,(HL+)		; D = x
+	LD	D, A
 	LD	E,(HL)		; E = y
 	LDA	HL,9(SP)
-	LD	B,(HL)		; BC = tiles
-	DEC	HL
-	LD	C,(HL)
-	DEC	HL
+	LD	A,(HL-)		; BC = tiles
+	LD	B, A
+	LD	A,(HL-)
+	LD	C, A
 	LD	A,(HL-)		; A = h
 	LD	H,(HL)		; H = w
 	LD	L,A		; L = h

--- a/gbdk-lib/libc/gb/set_prop.s
+++ b/gbdk-lib/libc/gb/set_prop.s
@@ -20,8 +20,8 @@ _set_sprite_prop::
 	PUSH	BC
 
 	LDA	HL,4(SP)	; Skip return address and registers
-	LD	C,(HL)		; C = nb
-	INC	HL
+	LD	A,(HL+)		; C = nb
+	LD	C,A
 	LD	D,(HL)		; D = prop
 
 	CALL	.set_sprite_prop

--- a/gbdk-lib/libc/gb/set_spr.s
+++ b/gbdk-lib/libc/gb/set_spr.s
@@ -20,8 +20,8 @@ _set_sprite_tile::
 	PUSH	BC
 
 	LDA	HL,4(SP)	; Skip return address and registers
-	LD	C,(HL)		; C = nb
-	INC	HL
+	LD	A,(HL+)		; C = nb
+	LD	C, A
 	LD	D,(HL)		; D = tile
 
 	CALL	.set_sprite_tile

--- a/gbdk-lib/libc/gb/set_wi_t.s
+++ b/gbdk-lib/libc/gb/set_wi_t.s
@@ -9,14 +9,14 @@ _set_win_tiles::
 	PUSH	BC
 
 	LDA	HL,4(SP)	; Skip return address and registers
-	LD	D,(HL)		; D = x
-	INC	HL
+	LD	A,(HL+)		; D = x
+	LD	D, A
 	LD	E,(HL)		; E = y
 	LDA	HL,9(SP)
-	LD	B,(HL)		; BC = tiles
-	DEC	HL
-	LD	C,(HL)
-	DEC	HL
+	LD	A,(HL-)		; BC = tiles
+	LD	B, A
+	LD	A,(HL-)
+	LD	C, A
 	LD	A,(HL-)		; A = h
 	LD	H,(HL)		; H = w
 	LD	L,A		; L = h

--- a/gbdk-lib/libc/gb/set_xy_t.s
+++ b/gbdk-lib/libc/gb/set_xy_t.s
@@ -79,19 +79,19 @@ _set_tiles::
 	PUSH	BC
 
 	LDA	HL,11(SP)	; Skip return address and registers
-	LD	B,(HL)		; BC = src
-	DEC	HL
-	LD	C,(HL)
-	DEC	HL
-	LD	D,(HL)		; DE = dst
-	DEC	HL
+	LD	A,(HL-)		; BC = src
+	LD	B, A
+	LD	A,(HL-)
+	LD	C, A
+	LD	A,(HL-)		; DE = dst
+	LD	D, A
 	LD	E,(HL)
 	LDA	HL,4(SP)	; Skip return address and registers
 	PUSH	DE		; Store address on stack for set_xy_tt
-	LD	D,(HL)		; D = x
-	INC	HL
-	LD	E,(HL)		; E = y
-	INC	HL
+	LD	A,(HL+)		; D = x
+	LD	D, A
+	LD	A,(HL+)		; E = y
+	LD	E, A
 	LD	A,(HL+)		; A = w
 	LD	L,(HL)		; L = h
 	LD	H,A		; H = w


### PR DESCRIPTION
Only when a is obviously used afterwards
Each one of them saves 2 cycles
In rare cases I could even save 3 cycles and 1 byte

--
I test compiled gbdk-2020, but I have no project for testing functionality.
I think I found all typos, this replacement is quite monotonic.