### PR TITLE
Fix MBC5 for 32K ROMs

### DIFF
--- a/gbdk-lib/libc/gb/crt0.s
+++ b/gbdk-lib/libc/gb/crt0.s
@@ -279,7 +279,7 @@ banked_call::			; Performs a long call.
 	.if __RGBDS__
 	.dw	BANK(_main)
 	.else
-	.dw	0
+	.dw	#1
 	.endif
 _exit::	
 99$:


### PR DESCRIPTION
This assumes main being in bank 1 instead of 0
Bank 0 is always loaded anyways
- should fix the MBC write exception in BGB
- allows 32K ROMs on MBC5 without manually switching to “bank 1” at the start of `main()`
- allows 32K ROMs on MBC5 where main moved into “bank 1”, even though I have my doubts this could happen