### PR TITLE
link-gbz80: Increase linker symbol limit from 32 chars to 100

### DIFF
--- a/link/z80/aslink.h
+++ b/link/z80/aslink.h
@@ -14,7 +14,7 @@
  */
 #include <limits.h>
 #ifndef PATH_MAX
-#define PATH_MAX 4096 
+#define PATH_MAX 4096
 #endif
 
 #define	VERSION	"V01.75"
@@ -82,7 +82,7 @@
  */
 
 #ifdef SDK
-#define	NCPS	32		/* characters per symbol */
+#define	NCPS	100		/* characters per symbol */
 #else /* SDK */
 #define	NCPS	8		/* characters per symbol */
 #endif /* SDK */


### PR DESCRIPTION
This resolves an issue with symbols getting truncated during the link stage. 

This is particularly an issue when combined with local statics since they get their name appended to filename  +functionname.

For example:
player_piece.c
UINT8 player_piece_move(INT8 dir_x, INT8 dir_y) {
    static INT8 new_x;
    static INT8 new_y;

Compiles correctly, but on linking I was getting this error:
"Multiple definition of Lplayer_piece.player_piece_move$x���.�Q���@"

link-gbz80 has a 32 character limit for symbols:
aslink.h: #define    NCPS    32        /* characters per symbol */

So these distinct symbols:
S Lplayer_piece.player_piece_move$new_x$1$146 Def000D
S Lplayer_piece.player_piece_move$new_y$1$146 Def000E

Get truncated to non-unique versions:
S Lplayer_piece.player_piece_move$
S Lplayer_piece.player_piece_move$

