### PR TITLE
Fix -S flag in LCC

### DIFF
--- a/gbdk-support/lcc/gb.c
+++ b/gbdk-support/lcc/gb.c
@@ -2,6 +2,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 #include <assert.h>
 #include <ctype.h>
 
@@ -306,7 +307,8 @@ void set_gbdk_dir(char* argv_0)
 	}
 #else
 	char slash = '/';
-	strcpy(buf, argv_0);
+	strncpy(buf, argv_0, sizeof(buf));
+	buf[sizeof(buf) - 1] = '\0';
 #endif
 
 	// Strip of the trailing GBDKDIR/bin/lcc.exe and use it as the prefix.
@@ -320,7 +322,7 @@ void set_gbdk_dir(char* argv_0)
 		if (p) {
 			*++p = '\0';
 			char quotedBuf[1024];
-			sprintf(quotedBuf, "\"%s\"", buf);
+			snprintf(quotedBuf, 1024, "\"%s\"", buf);
 			setTokenVal("prefix", quotedBuf);
 		}
 	}


### PR DESCRIPTION
Fixes #52 (introduced in commit https://github.com/Zal0/gbdk-2020/commit/4928c8884bd2cc05130bce816f203473c7cf925a)

While I'm at it, fix some other things:
* use header files to get function prototypes rather than defining them ourselves
* Include stdlib.h in gb.c to get the definition for exit
* prevent several possible overflows
* use proper types for PIDs