### PR TITLE
LCC: Change default stack location from 0xDEFF to 0xE000 (end of WRAM1)

### DIFF
--- a/gbdk-support/lcc/gb.c
+++ b/gbdk-support/lcc/gb.c
@@ -25,7 +25,7 @@ typedef struct {
 	const char *com;
 	const char *as;
 	const char *ld;
-	const char *mkbin; 
+	const char *mkbin;
 } CLASS;
 
 static struct {
@@ -298,7 +298,7 @@ void finalise(void)
 
 void set_gbdk_dir(char* argv_0)
 {
-	char buf[1024];
+	char buf[1024 - 2]; // Path will get quoted below, so reserve two characters for them
 #ifdef __WIN32__
 	char slash = '\\';
 	if (GetModuleFileName(NULL,buf, sizeof(buf)) == 0)
@@ -322,7 +322,7 @@ void set_gbdk_dir(char* argv_0)
 		if (p) {
 			*++p = '\0';
 			char quotedBuf[1024];
-			snprintf(quotedBuf, 1024, "\"%s\"", buf);
+			snprintf(quotedBuf, sizeof(quotedBuf), "\"%s\"", buf);
 			setTokenVal("prefix", quotedBuf);
 		}
 	}

--- a/gbdk-support/lcc/lcc.c
+++ b/gbdk-support/lcc/lcc.c
@@ -208,7 +208,7 @@ int main(int argc, char *argv[]) {
 static void Fixllist()
 {
 	#define BEGINS_WITH(A, B) (A ? strncmp(A, B, sizeof(B) - 1) == 0 : 0)
-	//-g .OAM=0xC000 -g .STACK=0xDEFF -g .refresh_OAM=0xFF80 -b _DATA=0xc0a0 -b _CODE=0x0200
+	//-g .OAM=0xC000 -g .STACK=0xE000 -g .refresh_OAM=0xFF80 -b _DATA=0xc0a0 -b _CODE=0x0200
 
 	int oamDefFound = 0;
 	int stackDefFound = 0;
@@ -242,7 +242,7 @@ static void Fixllist()
     }
 	if(!stackDefFound){
 		llist[0] = append("-g", llist[0]);
-        llist[0] = append(".STACK=0xDEFF", llist[0]);
+        llist[0] = append(".STACK=0xE000", llist[0]);
     }
 	if(!refreshOAMDefFound) {
         llist[0] = append("-g", llist[0]);


### PR DESCRIPTION
Not sure if there was a specific reason the default stack location got moved to 0xDEFF? 

It seems like it should be at 0xE000, which is also where the old versions of GBDK located it.

At the current location it would effectively create a block of 0x101 bytes after the stack that might go unused by default (unless explicitly specified).