### PR TITLE
Fix time() calculation of seconds. Use 60hz instead of 100hz (or 50)

### DIFF
--- a/gbdk-lib/include/time.h
+++ b/gbdk-lib/include/time.h
@@ -6,13 +6,7 @@
 
 #include <types.h>
 
-#if SDCC_PLAT==consolez80
-#define CLOCKS_PER_SEC		100
-#else
-/** For now... */
-#error
-#define CLOCKS_PER_SEC		50
-#endif
+#define CLOCKS_PER_SEC		60
 
 typedef UINT16	time_t;
 


### PR DESCRIPTION
Seems like the time() seconds calculation should be dividing sys_time by 60 instead of 100...?

time() is essentially using sys_time / CLOCKS_PER_SEC, and sys_time is incremented once per VBL (~60 hz). Neither 100 nor 50 match the frame rate, and so yields an incorrect seconds calculation.

I could be misunderstanding this, but it seems like it's wrong. A test showed it's off by the amount predicted by the 60hz vs 100hz difference.