### PR TITLE
Lcc: -S flag as per lcc help output - Compile only; do not assemble or link

### DIFF
--- a/gbdk-support/lcc/gb.c
+++ b/gbdk-support/lcc/gb.c
@@ -46,6 +46,7 @@ static struct {
 		{ "comopt",		"--noinvariant --noinduction" },
 		{ "commodel", 	"small" },
 		{ "com",		"%sdccdir%sdcc" },
+		{ "comflag",    "-c"},
 		{ "comdefault",	"-mgbz80 --no-std-crt0 --fsigned-char --use-stdout" },
 		{ "as",		"%sdccdir%sdasgb" },
 		{ "ld",		"%sdccdir%sdldgb" },
@@ -91,7 +92,7 @@ static CLASS classes[] = {
 			"gb",
 			"%cpp% %cppdefault% -DGB=1 -DGAMEBOY=1 -DINT_16_BITS $1 $2 $3",
 			"%includedefault%",
-			"%com% %comdefault% -Wa-pog -DGB=1 -DGAMEBOY=1 -DINT_16_BITS $1 -c $2 -o $3",
+			"%com% %comdefault% -Wa-pog -DGB=1 -DGAMEBOY=1 -DINT_16_BITS $1 %comflag% $2 -o $3",
 			"%as% -pog $1 $3 $2",
 			"%ld% -n -i $1 -k %libdir%%port%/ -l %port%.lib "
 				"-k %libdir%%plat%/ -l %plat%.lib $3 %libdir%%plat%/crt0.o $2",
@@ -251,7 +252,12 @@ int option(char *arg) {
 		setTokenVal("includedir", tail);
 		return 1;
 	}
-	else if ((tail = starts_with(arg, "-m"))) {
+	else if ((tail = starts_with(arg, "-S"))) {
+		// -S is compile to ASM only
+		// When composing the compile stage, swap in of -S instead of default -c
+		setTokenVal("comflag", "-S");
+	}
+    else if ((tail = starts_with(arg, "-m"))) {
 		/* Split it up into a asm/port pair */
 		char *slash = strchr(tail, '/');
 		if (slash) {

--- a/gbdk-support/lcc/lcc.c
+++ b/gbdk-support/lcc/lcc.c
@@ -175,7 +175,8 @@ int main(int argc, char *argv[]) {
 				error("can't find `%s'", argv[i]);
 		}
 
-	if (errcnt == 0 && !Eflag && !Sflag && !cflag && llist[1]) {
+    // Perform Link stage unless some conditions prevent it
+	if (errcnt == 0 && !Eflag && !cflag && !Sflag && llist[1]) {
 		if(!outfile)
 			outfile = concat("a", first(suffixes[4]));
 
@@ -542,11 +543,16 @@ static int filename(char *name, char *base) {
 			char *ofile;
 			if ((cflag || Sflag) && outfile)
 				ofile = outfile;
-			else if (cflag || Sflag)
+			else if (cflag)
 				ofile = concat(base, first(suffixes[3]));
+			else if (Sflag) {
+				// When compiling to asm only, set outfile as .asm
+				ofile = concat(base, ".asm");
+			}
 			else
 			{
-				ofile = tempname(first(suffixes[3]));
+    			ofile = tempname(first(suffixes[3]));
+
 				char* ofileBase = basepath(ofile);
 				rmlist = append(stringf("%s/%s%s", tempdir, ofileBase, ".asm"), rmlist);
 				rmlist = append(stringf("%s/%s%s", tempdir, ofileBase, ".lst"), rmlist);
@@ -815,8 +821,9 @@ static void opt(char *arg) {
 	}
 	if (arg[2] == 0)
 		switch (arg[1]) {	/* single-character options */
-		case 'S':
+		case 'S':        // Requested compile to assembly only
 			Sflag++;
+			option(arg); // Update composing the compile stage, use of -S instead of -c
 			return;
 		case 'O':
 			fprintf(stderr, "%s: %s ignored\n", progname, arg);


### PR DESCRIPTION
Preface: I'm not particularly attached to this PR. No worries if it isn't desirable to merge this. Mostly doing since @JL2210 prompted a further review of why -S didn't work as advertised, which I'd started and then stopped a while back.

This seems like an alright approach, there might be other and better way to do it.

This does not attempt to block contradictory flags if there are any

@JL2210 If you can test this out and confirm it's what you expect, that would be helpful.
