### PR TITLE
LCC: fix for #68, *.adb files aren't cleaned up when -Wf--debug is specified

### DIFF
--- a/gbdk-support/lcc/lcc.c
+++ b/gbdk-support/lcc/lcc.c
@@ -551,6 +551,7 @@ static int filename(char *name, char *base) {
 				rmlist = append(stringf("%s/%s%s", tempdir, ofileBase, ".asm"), rmlist);
 				rmlist = append(stringf("%s/%s%s", tempdir, ofileBase, ".lst"), rmlist);
 				rmlist = append(stringf("%s/%s%s", tempdir, ofileBase, ".sym"), rmlist);
+				rmlist = append(stringf("%s/%s%s", tempdir, ofileBase, ".adb"), rmlist);
 			}
 
 			compose(com, clist, append(name, 0), append(ofile, 0));


### PR DESCRIPTION
Fix for #68 
Add .adb to the list of intermediate file types to delete (rmlist) so that they get cleaned up when the debug build is complete.

Currently they just get left in the default temp directory (or in the user specified temp directory if -tempdir= is used).

For reference: *.adb files are generated when -Wf--debug is specified, and are used to further generate .cdb files

