### PR TITLE
Clarify the use of lcc

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You don't need the sources, unless you wish to compile GBDK-2020 yourself. Downl
 # Current status
 - updated CRT and library that suits better for game development
 - the latest nightlies of **sdcc** (the compiler and toolchain) are used from [sourceforge](http://sdcc.sourceforge.net). At the moment of writing this the last stable version is 4.0 which has linker issues and won't work if you want to use banks. Please use one of the nightlies available [here](http://sdcc.sourceforge.net/snap.php) (we used 11875)
-- **lcc** (the retargetable compiler) supports the latest version of sdcc compiler and toolchain. 
+- The compiler driver **lcc** supports the latest sdcc toolchain.
 
 For full list of changes see the [ChangeLog](https://github.com/Zal0/gbdk-2020/blob/master/gbdk-support/ChangeLog) file
 

--- a/gbdk-support/README
+++ b/gbdk-support/README
@@ -43,10 +43,6 @@ Reporting problems and feature requests
     http://sourceforge.net/project/?group_id=1249
 5.  Check if anyone else has reported the problem
     http://sourceforge.net/bugs/?group_id=1249
-6.  Submit a new bug using the link above.  It is _very_ helpful if you can 
-    show how to reproduce the bug and/or give me the source to try and/or
-    use the --dumpall (lcc -Wf--dumpall) option and send me all of the *.dump
-    files.  Use the email address below.
 
 To download the latest source, get the tarball on sourceforge,
 extract, and type:


### PR DESCRIPTION
Historically, GBDK was shipped with the modified LCC described in the
book "A Retargetable C Compiler: Design and Implementation." However,
SDCC has been the actual C compiler for GBDK, and the program "lcc" is
now the wrapper of SDCC. That is, "lcc" is the compiler driver rather
a C compiler for the sake of compatibility. This patch removed
misleading descriptions about LCC.

A compiler driver is a program which invokes the other components of
the tool set to process a program. The compiler driver uses command
line arguments and source file extensions to determine which compiler
or assembler to invoke for each source file, then sequence the
resulting output through the subsequent linker and conversion
utilities, relieving the user of the burden of invoking each of these
tools individually.