### PR TITLE
Improve the rules to install SDCC executables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,27 +171,23 @@ gbdk-lib-examples-makefile:
 	$(MAKE) -C $(BUILDDIR)/examples/gb make.bat
 	unix2dos $(BUILDDIR)/examples/gb/make.bat
 
-#SDDC copy
+# Copy SDDC executable files
+SDCC_BINS = as2gbmap makebin packihx sdar sdasgb sdcc sdcdb sdcdb sdcpp sdldgb sdnm sdobjcopy sdranlib sz80
+ifeq ($(OS),Windows_NT)
+MINGW64_RUNTIME = \
+	libgcc_s_seh-1.dll \
+	libgcc_s_sjlj-1.dll \
+	libstdc++-6.dll \
+	libwinpthread-1.dll \
+	readline5.dll
+SDCC_BINS := $(addsuffix .exe, $(SDCC_BINS)) $(MINGW64_RUNTIME)
+endif
+
 sdcc-install: check-SDCCDIR
 	@echo Installing SDCC
-ifeq ($(OS),Windows_NT)
-		@cp -r $(SDCCDIR)/bin $(BUILDDIR)
-else
-#		@cp $(SDCCDIR)/bin/{as2gbmap,makebin,packihx,sdar,sdasgb,sdcc,sdcdb,sdcdb{,src}.el,sdcpp,sdldgb,sdnm,sdobjcopy,sdranlib,sz80} $(BUILDDIR)/bin/
-		@cp $(SDCCDIR)/bin/as2gbmap $(BUILDDIR)/bin/
-		@cp $(SDCCDIR)/bin/makebin $(BUILDDIR)/bin/
-		@cp $(SDCCDIR)/bin/packihx $(BUILDDIR)/bin/
-		@cp $(SDCCDIR)/bin/sdar $(BUILDDIR)/bin/
-		@cp $(SDCCDIR)/bin/sdasgb $(BUILDDIR)/bin/
-		@cp $(SDCCDIR)/bin/sdcc $(BUILDDIR)/bin/
-		@cp $(SDCCDIR)/bin/sdcdb $(BUILDDIR)/bin/
-		@cp $(SDCCDIR)/bin/sdcpp $(BUILDDIR)/bin/
-		@cp $(SDCCDIR)/bin/sdldgb $(BUILDDIR)/bin/
-		@cp $(SDCCDIR)/bin/sdnm $(BUILDDIR)/bin/
-		@cp $(SDCCDIR)/bin/sdobjcopy $(BUILDDIR)/bin/
-		@cp $(SDCCDIR)/bin/sdranlib $(BUILDDIR)/bin/
-		@cp $(SDCCDIR)/bin/sz80 $(BUILDDIR)/bin/
-endif
+	@for i in $(SDCC_BINS); do \
+	cp $(SDCCDIR)/bin/$$i $(BUILDDIR)/bin/ && echo "-> $$i" ; \
+	done
 
 # Final binary
 binary:


### PR DESCRIPTION
This patch specifies the predefined list for SDCC executable files for
GBDK installation. For x86_64-w64-mingw32 target, the extra DLL files
are copied as the necessary runtime.
