### PR TITLE
BankPack: Calculate cart size (-cartsize)

### DIFF
--- a/gbdk-support/bankpack/bankpack.c
+++ b/gbdk-support/bankpack/bankpack.c
@@ -12,6 +12,7 @@
 #include "files.h"
 
 bool g_option_verbose = false;
+bool g_option_cartsize = false;
 
 static void display_help(void);
 static int handle_args(int argc, char * argv[]);
@@ -39,6 +40,7 @@ static void display_help(void) {
        "-path=<path> : Write files out to <path> (<path> *MUST* already exist)\n"
        "-sym=<prefix>: Add symbols starting with <prefix> to match + update list.\n"
        "               Default entry is \"___bank_\" (see below)\n"
+       "-cartsize    : Print min required cart size as \"autocartsize:<NNN>\"\n"
        "-v           : Verbose output, show assignments\n"
        "\n"
        "Example: \"bankpack -ext=.rel -path=some/newpath/ file1.o file2.o\"\n"
@@ -93,6 +95,8 @@ static int handle_args(int argc, char * argv[]) {
                 option_set_verbose(true);
             } else if (strstr(argv[i], "-sym=")) {
                 symbol_match_add(argv[i] + 5);
+            } else if (strstr(argv[i], "-cartsize")) {
+                g_option_cartsize = true;
             } else
                 printf("BankPack: Warning: Ignoring unknown option %s\n", argv[i]);
         } else {
@@ -144,8 +148,12 @@ int main( int argc, char *argv[] )  {
             // then rewrite object files as needed
             files_extract();
             files_rewrite();
+
             if (g_option_verbose)
                 banks_show();
+            if (g_option_cartsize)
+                fprintf(stdout,"autocartsize:%d\n",banks_calc_cart_size());
+
             cleanup();
             ret = EXIT_SUCCESS;
         } else

--- a/gbdk-support/bankpack/common.h
+++ b/gbdk-support/bankpack/common.h
@@ -22,6 +22,7 @@ enum {
 #define BANK_NUM_ROM_MIN      1
 #define BANK_NUM_ROM_MAX      255
 #define BANK_ROM_TOTAL        256 // Banks 0-255
+#define BANK_ROM_CALC_MAX     512 // Banks 0-512 (>256 not supported for auto-banking right now)
 #define BANK_SIZE_ROM         0x4000U
 
 #define BANK_NUM_ROM_MAX_MBC1  127

--- a/gbdk-support/bankpack/obj_data.h
+++ b/gbdk-support/bankpack/obj_data.h
@@ -42,6 +42,8 @@ int banks_get_mbc_type(void);
 void banks_set_mbc(int);
 void banks_set_mbc_by_rom_byte_149(int);
 
+uint32_t banks_calc_cart_size(void);
+
 bool banks_set_min(uint16_t bank_num);
 bool banks_set_max(uint16_t bank_num);
 

--- a/gbdk-support/lcc/lcc.c
+++ b/gbdk-support/lcc/lcc.c
@@ -208,7 +208,7 @@ int main(int argc, char *argv[]) {
 		}
 
 		// Call linker
-		// (fixlist dds required default linker vars if not added by user)
+		// (fixlist adds required default linker vars if not added by user)
 		Fixllist();
 		compose(ld, llist[0], llist[1], append(ihxFile, 0));
 		if (callsys(av))


### PR DESCRIPTION
@untoxa 

Adds auto-calculation of cartsize. It is rendered in stdout as "autocartsize:N", warn about fixed banks outside specified limits, fixes a recent typo in a lcc comment

(I could be wrong about this...)
For LCC it doesn't appear straightforward to capture STDOUT from the spawned bankpack child process, particularly because commands get executed in a different way between Windows and Linux.
* On Windows LCC uses _spawnvp() which is part of the API. I didn't see obvious support for capturing STDOUT from the child.
* On Linux LCC uses a custom function to emulate the behavior of _spawnvp(). With that function it may be do-able using dup2() and a pipe.

