### PR TITLE
LCC: Update version reported to 2.0 and use actual build date

### DIFF
--- a/gbdk-support/lcc/Makefile
+++ b/gbdk-support/lcc/Makefile
@@ -4,8 +4,12 @@ ifndef TARGETDIR
 TARGETDIR = /opt/gbdk
 endif
 
+BUILDDATE=$(shell date --utc +%Y/%m/%d)
+BUILDTIME=$(shell date --utc +%H:%M:%S)
+
 CC = $(TOOLSPREFIX)gcc
 CFLAGS = -ggdb -O -Wno-incompatible-pointer-types -DGBDKLIBDIR=\"$(TARGETDIR)\"
+CFLAGS += -DBUILDDATE=\"$(BUILDDATE)\" -DBUILDTIME=\"$(BUILDTIME)\"
 OBJ = lcc.o gb.o
 BIN = lcc
 

--- a/gbdk-support/lcc/lcc.c
+++ b/gbdk-support/lcc/lcc.c
@@ -2,7 +2,7 @@
  * lcc [ option ]... [ file | -llib ]...
  * front end for the ANSI C compiler
  */
-static char rcsid[] = "$Id: lcc.c,v 1.6 2001/10/28 18:38:13 michaelh Exp $";
+static char rcsid[] = "$Id: lcc.c,v 2.0 " BUILDDATE " " BUILDTIME " gbdk-2020 Exp $";
 
 #include <stdio.h>
 #include <stdarg.h>
@@ -676,7 +676,7 @@ static void help(void) {
 "-P	print ANSI-style declarations for globals\n",
 "-p -pg	emit profiling code; see prof(1) and gprof(1)\n",
 "-S	compile to assembly language\n",
-"-autobank auto-assign banks set to 255 (bankpack)"
+"-autobank auto-assign banks set to 255 (bankpack)\n"
 #ifdef linux
 "-static	specify static libraries (default is dynamic)\n",
 #endif


### PR DESCRIPTION
For #102 
- Updates version reported to 2.0
- Reports actual build date (in UTC)  instead of 2001/10/28
- Also fixes missing line break in help output

Tested on Windows and Linux.
```
$ ./lcc -v
./lcc $Id: lcc.c,v 2.0 2020/12/18 06:54:16 gbdk-2020 Exp $
```