### PR TITLE
Bankpack: Fix incorrect filtering of symbols to rewrite

### DIFF
--- a/gbdk-support/bankpack/obj_data.h
+++ b/gbdk-support/bankpack/obj_data.h
@@ -10,6 +10,7 @@
 #define OBJ_NAME_MAX_STR_LEN 255
 #define AREA_LINE_RECORDS      2 // Bank number, Size
 #define SYMBOL_LINE_RECORDS    2 // Name, DefVal
+#define SYMBOL_REWRITE_RECORDS 2 // Name, DefVal
 
 
 typedef struct bank_item {


### PR DESCRIPTION
The filtering of symbols to rewrite was failing to require exact match of trailing `Def0000FF`. Add an additional sscanf param for the bank number and make sure it's the one that indicates auto-banking.