### PR TITLE
Lib: Pull in updated linking exemption headers from SDCC versions

### DIFF
--- a/gbdk-lib/libc/_divslong.c
+++ b/gbdk-lib/libc/_divslong.c
@@ -1,25 +1,29 @@
 /*-------------------------------------------------------------------------
    _divslong.c - routine for division of 32 bit long
 
-             Written By -  Sandeep Dutta . sandeep.dutta@usa.net (1999)
+   Copyright (C) 1999, Sandeep Dutta . sandeep.dutta@usa.net
 
    This library is free software; you can redistribute it and/or modify it
-   under the terms of the GNU Library General Public License as published by the
+   under the terms of the GNU General Public License as published by the
    Free Software Foundation; either version 2, or (at your option) any
    later version.
 
    This library is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU Library General Public License for more details.
+   GNU General Public License for more details.
 
-   You should have received a copy of the GNU Library General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+   You should have received a copy of the GNU General Public License
+   along with this library; see the file COPYING. If not, write to the
+   Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+   MA 02110-1301, USA.
 
-   In other words, you are welcome to use, share and improve this program.
-   You are forbidden to forbid anyone else to use, share and improve
-   what you give them.   Help stamp out software-hoarding!
+   As a special exception, if you link this library with other files,
+   some of which are compiled with SDCC, to produce an executable,
+   this library does not by itself cause the resulting executable to
+   be covered by the GNU General Public License. This exception does
+   not however invalidate any other reasons why the executable file
+   might be covered by the GNU General Public License.
 -------------------------------------------------------------------------*/
 
 #ifndef GBDK

--- a/gbdk-lib/libc/_modslong.c
+++ b/gbdk-lib/libc/_modslong.c
@@ -1,25 +1,29 @@
 /*-------------------------------------------------------------------------
    _modslong.c - routine for modulus of 32 bit signed long
 
-             Written By -  Sandeep Dutta . sandeep.dutta@usa.net (1999)
+   Copyright (C) 1999, Sandeep Dutta . sandeep.dutta@usa.net
 
    This library is free software; you can redistribute it and/or modify it
-   under the terms of the GNU Library General Public License as published by the
+   under the terms of the GNU General Public License as published by the
    Free Software Foundation; either version 2, or (at your option) any
    later version.
 
    This library is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU Library General Public License for more details.
+   GNU General Public License for more details.
 
-   You should have received a copy of the GNU Library General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+   You should have received a copy of the GNU General Public License
+   along with this library; see the file COPYING. If not, write to the
+   Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+   MA 02110-1301, USA.
 
-   In other words, you are welcome to use, share and improve this program.
-   You are forbidden to forbid anyone else to use, share and improve
-   what you give them.   Help stamp out software-hoarding!
+   As a special exception, if you link this library with other files,
+   some of which are compiled with SDCC, to produce an executable,
+   this library does not by itself cause the resulting executable to
+   be covered by the GNU General Public License. This exception does
+   not however invalidate any other reasons why the executable file
+   might be covered by the GNU General Public License.
 -------------------------------------------------------------------------*/
 
 #ifndef GBDK

--- a/gbdk-lib/libc/_modulong.c
+++ b/gbdk-lib/libc/_modulong.c
@@ -1,27 +1,30 @@
 /*-------------------------------------------------------------------------
    _modulong.c - routine for modulus of 32 bit unsigned long
 
-             Written By -  Sandeep Dutta . sandeep.dutta@usa.net (1999)
-
+   Copyright (C) 1999, Sandeep Dutta . sandeep.dutta@usa.net
              Bug fixes by Martijn van Balen, aed@iae.nl
 
    This library is free software; you can redistribute it and/or modify it
-   under the terms of the GNU Library General Public License as published by the
+   under the terms of the GNU General Public License as published by the
    Free Software Foundation; either version 2, or (at your option) any
    later version.
 
    This library is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU Library General Public License for more details.
+   GNU General Public License for more details.
 
-   You should have received a copy of the GNU Library General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+   You should have received a copy of the GNU General Public License
+   along with this library; see the file COPYING. If not, write to the
+   Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+   MA 02110-1301, USA.
 
-   In other words, you are welcome to use, share and improve this program.
-   You are forbidden to forbid anyone else to use, share and improve
-   what you give them.   Help stamp out software-hoarding!
+   As a special exception, if you link this library with other files,
+   some of which are compiled with SDCC, to produce an executable,
+   this library does not by itself cause the resulting executable to
+   be covered by the GNU General Public License. This exception does
+   not however invalidate any other reasons why the executable file
+   might be covered by the GNU General Public License.
 -------------------------------------------------------------------------*/
 
 /*   Assembler-functions are provided for:


### PR DESCRIPTION
This should take care of the licensing questions in #114.

SDCC clarified and fixed up the linking exemption headers in 2010:
https://sourceforge.net/p/sdcc/code/5737/
>  device/lib/*.c: sdcc library license changed to GPL+LE

Only the updated header comments are merged in for now, it leaves the files otherwise unchanged. Later, if someone wants to spend a little time doing a review and some testing, the code changes that have occurred since then could be merged too. modslong and modulong have changed very little, but divslong has changed more (mostly variable naming).

https://sourceforge.net/p/sdcc/code/HEAD/tree/trunk/sdcc/device/lib/_modulong.c
History: https://sourceforge.net/p/sdcc/code/12015/log/?path=/trunk/sdcc/device/lib/_modulong.c

https://sourceforge.net/p/sdcc/code/HEAD/tree/trunk/sdcc/device/lib/_modslong.c
History: https://sourceforge.net/p/sdcc/code/12015/log/?path=/trunk/sdcc/device/lib/_modslong.c

https://sourceforge.net/p/sdcc/code/HEAD/tree/trunk/sdcc/device/lib/_divslong.c
History: https://sourceforge.net/p/sdcc/code/12015/log/?path=/trunk/sdcc/device/lib/_divslong.c

