### PR TITLE
LCC: add -debug for default compiler and linker debug flags

### DIFF
--- a/gbdk-support/lcc/lcc.c
+++ b/gbdk-support/lcc/lcc.c
@@ -671,6 +671,7 @@ static void help(void) {
 "-Bdir/	use the compiler named `dir/rcc'\n",
 "-c	compile only\n",
 "-dn	set switch statement density to `n'\n",
+"-debug	turn on --debug for compiler, -y (.cdb) and -j (.noi) for linker\n",
 "-Dname -Dname=def	define the preprocessor symbol `name'\n",
 "-E	run only the preprocessor on the named C programs and unsuffixed files\n",
 "-g	produce symbol table information for debuggers\n",
@@ -820,6 +821,14 @@ static void opt(char *arg) {
 		fprintf(stderr, "%s: %s ignored\n", progname, arg);
 		return;
 	case 'd':	/* -dn */
+		if (strcmp(arg, "-debug") == 0) {
+			// Load default debug options
+			clist    = append("--debug", clist);  // Debug for sdcc compiler
+			llist[0] = append("-y", llist[0]);    // Enable .cdb output for sdldgb linker
+			llist[0] = append("-j", llist[0]);    // Enable .noi output
+			return;
+		}
+
 		arg[1] = 's';
 		clist = append(arg, clist);
 		return;


### PR DESCRIPTION
Re #118, add a convenience -debug option for lcc which turns on:  
 - ` --debug` for sdcc
 - `-y` (.cdb) and `-j` (.noi) for sdldgb

Also listed in lcc help output:
`-debug        turn on --debug for compiler, -y (.cdb) and -j (.noi) for linker`

lcc build and example project build tested ok on Linux & Windows