### PR TITLE
Remove duplicate sdcdb entry.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ gbdk-lib-examples-makefile:
 	unix2dos $(BUILDDIR)/examples/gb/make.bat
 
 # Copy SDDC executable files
-SDCC_BINS = makebin packihx sdar sdasgb sdcc sdcdb sdcdb sdcpp sdldgb sdnm sdobjcopy sdranlib sz80
+SDCC_BINS = makebin packihx sdar sdasgb sdcc sdcdb sdcpp sdldgb sdnm sdobjcopy sdranlib sz80
 ifeq ($(OS),Windows_NT)
 MINGW64_RUNTIME = \
 	libgcc_s_seh-1.dll \


### PR DESCRIPTION
Without this, `make` tries to `cp` sdcdb twice; since my installation
of sdcc is read-only, this gives me:

```
cp: cannot create regular file '/data/auto/sources/gbdk-2020/build/gbdk/bin/sdcdb': Permission denied
```

The fix seems innocent enough, and WorksForMe (tm)

----

#