### PR TITLE
Allow to set --sdccbindir via cli flag

### DIFF
--- a/gbdk-support/lcc/gb.c
+++ b/gbdk-support/lcc/gb.c
@@ -51,12 +51,12 @@ static struct {
 		{ "comflag",    "-c"},
 		{ "comdefault",	"-mgbz80 --no-std-crt0 --fsigned-char --use-stdout" },
 		{ "as",		"%sdccdir%sdasgb" },
-		{ "bankpack", "%sdccdir%bankpack" },
+		{ "bankpack", "%bindir%bankpack" },
 		{ "ld",		"%sdccdir%sdldgb" },
 		{ "libdir",		"%prefix%lib/%libmodel%/asxxxx/" },
 		{ "libmodel",	"small" },
 		{ "bindir",		"%prefix%bin/" },
-		{ "ihxcheck", "%sdccdir%ihxcheck" },
+		{ "ihxcheck", "%bindir%ihxcheck" },
 		{ "mkbin", "%sdccdir%makebin" }
 };
 
@@ -262,6 +262,11 @@ int option(char *arg) {
 	}
 	else if ((tail = starts_with(arg, "--gbdkincludedir="))) {
 		setTokenVal("includedir", tail);
+		return 1;
+	}
+	else if ((tail = starts_with(arg, "--sdccbindir="))) {
+		// Allow to easily run with external SDCC snapshot / release
+		setTokenVal("sdccdir", tail);
 		return 1;
 	}
 	else if ((tail = starts_with(arg, "-S"))) {


### PR DESCRIPTION
Backport of 1a1e48b87064596bf697f959293825f72c0c780c

Allows to easily run with external SDCC snapshot / release through `--sdccbindir=`.
It's especially needed if gbdk is located at a write protected location or when it’s undesirable to fix the sdcc binaries in gbdk-2020 with symlinks.

It's analogous to the existing `--prefix=`, `--gbdklibdir=` and `--gbdkincludedir=`.