### PR TITLE
printf: try not to fail when encountering %0... %1-9... and upper case %X

### DIFF
--- a/gbdk-lib/libc/sprintf.c
+++ b/gbdk-lib/libc/sprintf.c
@@ -31,9 +31,18 @@ void __printf(const char *format, emitter_t emitter, char **pData, va_list va)
     char buf[16];
     while (*format) {
         if (*format == '%') {
-            switch (*++format) {
+            format++;
+
+            // 0 Padding is not supported, ignore
+            if (*format == '0') format++;
+
+            // Width Specifier is not supported, ignore 1 digit worth
+            if ((*format >= '1') && (*format <= '9')) format++;
+
+            switch (*format) {
                 case 'h': {
                     switch (*++format) {
+                        case 'X' :
                         case 'x' : {
                             _printhexbyte(va_arg(va, char), emitter, pData);
                             break;
@@ -70,6 +79,7 @@ void __printf(const char *format, emitter_t emitter, char **pData, va_list va)
                     _printbuf(buf, emitter, pData);
                     break;
                 }
+                case 'X':
                 case 'x':
                 {
                     _printhex(va_arg(va, int), emitter, pData);


### PR DESCRIPTION
Not sure if you'll want to merge these changes, but here's a PR just in case.

I added them because I was getting format mismatches when comparing linux console output vs GBDK BGB debug log output for the same program. GBDK2020 prints `%x` as if it was `%04X`, yet it doesn't support (fails to print) actual `%04X` when it's used.

- Ignore %0 padding and %1-9 width specifier instead of failing to print
- Support upper case X hex specifier by mapping as if it was %x (%x maps to uppercase right now anyway)

