### PR TITLE
Examples: Bankpack: Interim fix for build failure

### DIFF
--- a/gbdk-lib/examples/gb/banks_autobank/Makefile
+++ b/gbdk-lib/examples/gb/banks_autobank/Makefile
@@ -1,4 +1,5 @@
-CC	= ../../../bin/lcc -Wa-l -Wl-m
+LCC	= ../../../bin/lcc -Wa-l -Wl-m
+BANKPACK  = ../../../bin/bankpack
 
 # CFLAGS	=
 
@@ -11,7 +12,7 @@ OBJS       = $(CSOURCES:%.c=%.o) $(ASMSOURCES:%.c=%.o)
 
 # Process: .c and .s files -> .o -> (bankpack) -> .rel -> (linker) ... -> .gb
 #
-# In this makefile autobanked .o files get saved as .rel files (-Wb-ext=.rel)
+# In this makefile autobanked .o files get converted to .rel files (-ext=.rel)
 # which will be passed to the linker instead of .o files.
 #
 # This allows correct packing every time, even
@@ -25,27 +26,31 @@ make.bat: Makefile
 	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
 
 %.o:	%.c
-	$(CC) $(CFLAGS) -c -o $@ $<
+	$(LCC) $(CFLAGS) -c -o $@ $<
 
 %.o:	%.s
-	$(CC) $(CFLAGS) -c -o $@ $<
+	$(LCC) $(CFLAGS) -c -o $@ $<
 
 %.s:	%.c
-	$(CC) $(CFLAGS) -S -o $@ $<
+	$(LCC) $(CFLAGS) -S -o $@ $<
 
-# Link the compiled object files into a autobanks.gb ROM file
-# -autobank    : turns on auto banking
-# -Wb-v        : prints out assigned bank info
-# -Wb-ext=.rel : set output extension for autobanked files to .rel
+# Auto-bank the .o files into .rel files
+# (called with $(OBJS), which is .o files)
+# -v        : prints out assigned bank info
+# -ext=.rel : set output extension for autobanked files to .rel
+#
+# Link the compiled object files into a autobanks.gb ROM file 
+# (called with $(OBJS_AUTOBANKED), which is .rel files)
 # -Wl-yo4      : Use 4 ROM banks
 # -Wl-ya4      : Use 4 RAM banks
 # -Wl-yt19     : Use MBC5 cartridge type
 $(BINS):	$(OBJS)
-	$(CC) $(CFLAGS) -autobank -Wb-ext=.rel -Wb-v -Wl-yt19 -Wl-yo4 -Wl-ya4 -o $(BINS) $(OBJS_AUTOBANKED)
+	$(BANKPACK) -ext=.rel -v -yt19 $(OBJS)
+	$(LCC) $(CFLAGS) -Wl-yt19 -Wl-yo4 -Wl-ya4 -o $(BINS) $(OBJS_AUTOBANKED)
 #	./romusage autobanks.map -g
 
 clean:
-	rm -f *.o *.lst *.map *.gb *.ihx *.sym *.cdb *.adb *.asm
+	rm -f *.o *.lst *.map *.gb *.ihx *.sym *.cdb *.adb *.asm *.rel
 
 
 # For lcc linker option: -Wl-ytN where N is one of the numbers below


### PR DESCRIPTION
This is a fix for the Makefile for the time being:
- handle .rel and .o files in two separate steps, first bankpack .o -> .rel, then link .rel files

A larger fix is still needed.
When bankpack is called through lcc with "convert to .rel" ("-Wb-ext=.rel"), the link list is  passed in as ".o" and then converted to ".rel". __The problem__ is that LCC must then know to rewrite input list of files to link from ".o" into ".rel".

I'll spend more time thinking about how to fix this, but this PR should be OK for now.