### PR TITLE
fixed comment typo: immediatly -> immediately

### DIFF
--- a/gbdk-lib/include/gb/gb.h
+++ b/gbdk-lib/include/gb/gb.h
@@ -523,7 +523,7 @@ void reset(void) NONBANKED;
 
     Warning: If the VBL interrupt is disabled, this function will
     never return. If the screen is off this function returns
-    immediatly.
+    immediately.
 */
 void wait_vbl_done(void) NONBANKED __preserves_regs(b, c, d, e, h, l);
 

--- a/gbdk-lib/include/gb/gb.h
+++ b/gbdk-lib/include/gb/gb.h
@@ -553,7 +553,7 @@ void hiramcpy(UINT8 dst,
 #define DISPLAY_ON \
   LCDC_REG|=0x80U
 
-/** Turns the display off immediatly.
+/** Turns the display off immediately.
     @see display_off, DISPLAY_ON
 */
 #define DISPLAY_OFF \


### PR DESCRIPTION
the same issue occurs in the doc pages (https://zal0.github.io/gbdk-2020/docs/api/gb_8h.html#adf6ef63efc4bb4950428015c623bca14) but i cant find where to fix it in the repo lol